### PR TITLE
Support using the system's libnghttp2 instead of the bundled copy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+# modified by Maxime Devos (2022) (see 4(b) in LICENSE-APACHE)
 [package]
 name = "libnghttp2-sys"
 version = "0.1.7+1.45.0"
@@ -21,4 +22,9 @@ members = ['systest']
 libc = '0.2'
 
 [build-dependencies]
-cc = "1.0.24"
+cc = { version = "1.0.24", optional = true }
+pkg-config = { version = "0.3.19" }
+
+[features]
+vendored = ["cc"]
+default = ["vendored"] # for backwards compatibility

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,5 @@
 Copyright (c) 2014 Alex Crichton
+Copyright (c) 2022 Maxime Devos
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # nghttp2-sys
 
 A common library for linking `nghttp2` to rust programs (also known as
-libnghttp2).
+libnghttp2).  By default, it uses a bundled copy of `libnghttp2`.  If that
+is not desired, you can use the system's `libnghttp2` instead by not enabling
+the default `vendored` feature.
 
 ## Generating bindings
 
@@ -42,6 +44,7 @@ This project is licensed under either of
 
 at your option.
 
+Modified by Maxime Devos (2022) (see 4(b) in LICENSE-APACHE) (TODO: is there a less intrusive way to do this?)
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,24 @@
+// modified by Maxime Devos (2022) (see 4(b) in LICENSE-APACHE)
+
+#[cfg(feature = "vendored")]
 extern crate cc;
 
 use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-fn main() {
+#[cfg(not(feature = "vendored"))]
+extern crate pkg_config;
+
+// use system copy of nghttp2
+#[cfg(not(feature = "vendored"))]
+fn main_system() {
+    pkg_config::Config::new().atleast_version("1.44.0").probe("libnghttp2").unwrap();
+}
+
+// use bundled copy of nghttp2
+#[cfg(feature = "vendored")]
+fn main_vendored() {
     let target = env::var("TARGET").unwrap();
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let lib_version = env::var("CARGO_PKG_VERSION")
@@ -111,4 +125,12 @@ fn main() {
         include.join("nghttp2/nghttp2.h"),
     )
     .unwrap();
+}
+
+fn main() {
+    #[cfg(not(feature = "vendored"))]
+    main_system();
+
+    #[cfg(feature = "vendored")]
+    main_vendored();
 }


### PR DESCRIPTION
Warning:
  - The build system I use (antioxidant, not Cargo) hasn't implemented running tests yet
  - While it builds, the eventual binary to actually run doesn't compile yet (due to unrelated reasons) so it hasn't been verified yet whether it doesn't break anything.
  - The build system I use has a rather different dependency resolving algorithm.