### PR TITLE
Bump nghttp2 to 1.55.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libnghttp2-sys"
-version = "0.1.7+1.45.0"
+version = "0.1.7+1.55.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = 'nghttp2'
 license = "MIT/Apache-2.0"

--- a/build.rs
+++ b/build.rs
@@ -51,9 +51,11 @@ fn main() {
     let mut cfg = cc::Build::new();
     cfg.include("nghttp2/lib/includes")
         .include(&include)
+        .file("nghttp2/lib/sfparse.c")
         .file("nghttp2/lib/nghttp2_buf.c")
         .file("nghttp2/lib/nghttp2_callbacks.c")
         .file("nghttp2/lib/nghttp2_debug.c")
+        .file("nghttp2/lib/nghttp2_extpri.c")
         .file("nghttp2/lib/nghttp2_frame.c")
         .file("nghttp2/lib/nghttp2_hd.c")
         .file("nghttp2/lib/nghttp2_hd_huffman.c")


### PR DESCRIPTION
Upstream 1.55.1 (precisely, https://github.com/nghttp2/nghttp2/commit/ce385d3f55a4b76da976b3bdf71fe2deddf315ba) fixes [CVE-2023-35945](https://nvd.nist.gov/vuln/detail/CVE-2023-35945).