### PR TITLE
Bump nghttp2 to 1.58.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libnghttp2-sys"
-version = "0.1.8+1.55.1"
+version = "0.1.9+1.58.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = 'nghttp2'
 license = "MIT/Apache-2.0"

--- a/build.rs
+++ b/build.rs
@@ -75,9 +75,12 @@ fn main() {
         .file("nghttp2/lib/nghttp2_stream.c")
         .file("nghttp2/lib/nghttp2_submit.c")
         .file("nghttp2/lib/nghttp2_version.c")
+        .file("nghttp2/lib/nghttp2_ratelim.c")
+        .file("nghttp2/lib/nghttp2_time.c")
         .warnings(false)
         .define("NGHTTP2_STATICLIB", None)
         .define("HAVE_NETINET_IN", None)
+        .define("HAVE_TIME_H", None)
         .out_dir(&lib);
 
     if target.contains("windows") {


### PR DESCRIPTION
Fixed [CVE-2023-44487](https://github.com/nghttp2/nghttp2/security/advisories/GHSA-vx74-f528-fxqg).

Need to define `HAVE_TIME_H` to compile `nghttp2/lib/nghttp2_time.c`.