### PR TITLE
Add NGHTTP2_NO_VENDOR to compile with system nghttp2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ libc = '0.2'
 
 [build-dependencies]
 cc = "1.2.56"
+pkg-config = "0.3"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ The script requires that you have an up-to-date version of the bindgen CLI.
 The bindings are checked in CI to ensure that what exists in git matches the
 output of the script.
 
+## Building against a system libnghttp2
+
+By default this crate compiles and statically links a bundled copy of nghttp2.
+To link against the system library instead, set the environment variable:
+
+```sh
+NGHTTP2_NO_VENDOR=1
+```
+
 # License
 
 This project is licensed under either of

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,24 @@
 extern crate cc;
+extern crate pkg_config;
 
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+
+fn try_pkg_config(min_version: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let lib = pkg_config::Config::new()
+        .atleast_version(min_version)
+        .cargo_metadata(true)
+        .probe("libnghttp2")?;
+
+    let include = lib
+        .include_paths
+        .into_iter()
+        .next()
+        .ok_or("pkg-config returned no include paths")?;
+    let root = include.parent().map(|p| p.to_path_buf()).unwrap_or(include);
+    Ok(root)
+}
 
 fn main() {
     let target = env::var("TARGET").unwrap();
@@ -13,6 +29,18 @@ fn main() {
         .nth(1)
         .unwrap()
         .to_string();
+
+    if env::var("NGHTTP2_NO_VENDOR").as_deref() == Ok("1") {
+        match try_pkg_config(&lib_version) {
+            Ok(root) => println!("cargo:root={}", root.display()),
+            Err(err) => panic!(
+                "NGHTTP2_NO_VENDOR set but could not find libnghttp2 >= {}: {}",
+                lib_version, err
+            ),
+        }
+        return;
+    }
+
     let major = lib_version
         .split('.')
         .nth(0)


### PR DESCRIPTION
Allow compiling the system nghttp2 by specifying a NGHTTP2_NO_VENDOR flag at build-time. This mirrors similar flags in openssl, sqlite3, etc.